### PR TITLE
Fixed. repository link

### DIFF
--- a/puma-heroku.gemspec
+++ b/puma-heroku.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Puma integration for Heroku}
   spec.description   = %q{A Puma plugin that contains the default Heroku config}
-  spec.homepage      = "https://github.com/evanphx/puma-heroku"
+  spec.homepage      = "https://github.com/puma/puma-heroku"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
It seems Homepage link of https://rubygems.org/gems/puma-heroku/versions/1.1.0  is old

![image](https://user-images.githubusercontent.com/608755/64340572-6f38c380-d021-11e9-997f-4614285961b6.png)
