### PR TITLE
Sequel support

### DIFF
--- a/lib/puma/plugin/heroku.rb
+++ b/lib/puma/plugin/heroku.rb
@@ -16,6 +16,10 @@ Puma::Plugin.create do
         c.before_fork { ActiveRecord::Base.connection_pool.disconnect! }
         c.on_worker_boot { ActiveRecord::Base.establish_connection }
       end
+
+      if defined?(::Sequel)
+        c.before_fork { Sequel::DATABASES.each(&:disconnect) }
+      end
     end
   end
 


### PR DESCRIPTION
Close all Sequel connections before forking. There is no need to re-establish the connection later, as Sequel will automaticaly re-connect on first query (which is what Active Record does as well).

This adds the same support for Sequel as there is currently for Active Record.
